### PR TITLE
Allow for multiple score types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A library for keeping score, a practice project
 [![test](https://github.com/bdharris08/scorekeeper/actions/workflows/test.yml/badge.svg)](https://github.com/bdharris08/scorekeeper/actions/workflows/test.yml)
 
 ### Features
-`scoreKeeper.AddAction(action string) error`
+`scoreKeeper.AddAction(scoreType, action string) error`
 AddAction accepts a json-encoded action string like `"{"action":"hop", "time":100}"`.
-It will store the action as a Score in a ScoreStore for later stats calculations.
+It will store the action as a Score in a ScoreStore (categorized by scoreType) for later stats calculations.
 It can return the errors:
 - `ErrNoKeeper` = "scorekeeper uninitialized. Use New()"
 - `ErrNotRunning` = "scorekeeper not running. Use Start()"
+- Errors defined by the score type used, for example `score.ErrNoInput`
 
 `scoreKeeper.GetStats() (string, error)`
 GetStats will return a json-encoded list of average scores like `"[{"action":"hop", "avg":100}]"`.
@@ -25,78 +26,6 @@ You could implement your own using that interface. Just pass an initialized stor
 
 ### Example Usage
 
-#### Setup
-```go
+Memory Store: see [example/memory/README.md](./example/memory/README.md)
 
-import (
-    "github.com/bdharris08/scorekeeper"
-    "github.com/bdharris08/scorekeeper/store"
-)
-
-func main() {
-    scoreKeeper, err := scorekeeper.New(&store.MemoryStore{})
-	if err != nil {
-		panic(fmt.Errorf("error creating scoreKeeper: %w", err))
-	}
-
-	scoreKeeper.Start()
-	defer scoreKeeper.Stop()
-}
-```
-
-#### A simple example
-```go
-actions := []string{
-    `{"action":"hop", "time":100}`,
-    `{"action":"skip", "time":100}`,
-    `{"action":"hop", "time":100}`,
-}
-
-// A simple example
-for _, a := range actions {
-    if err := scoreKeeper.AddAction(a); err != nil {
-        fmt.Println(err)
-    }
-}
-result, err := scoreKeeper.GetStats()
-if err != nil {
-    fmt.Println(err)
-}
-// Do something with the result
-fmt.Println(result)
-```
-
-#### Concurrent example
-```go
-// You can even access the scoreKeeper concurrently!
-var wg sync.WaitGroup
-for i := 0; i < numWorkers; i++ {
-    wg.Add(1)
-
-    go func() {
-        defer wg.Done()
-        for _, a := range actions {
-            if err := scoreKeeper.AddAction(a); err != nil {
-                fmt.Println(err)
-            }
-        }
-        result, err := scoreKeeper.GetStats()
-        if err != nil {
-            fmt.Println(err)
-        }
-        // Do something with the result, 
-        // this will likely be an intermediate result 
-        // since not all workers will have finished
-        fmt.Println(result)
-    }()
-}
-
-wg.Wait()
-
-result, err = scoreKeeper.GetStats()
-if err != nil {
-    fmt.Println(err)
-}
-// Do something with the final result
-fmt.Println(result)
-```
+Postgres SQL Store: see [example/pgsql/README.md](./example/pgsql/README.md)

--- a/example/memory/main.go
+++ b/example/memory/main.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/bdharris08/scorekeeper"
+	"github.com/bdharris08/scorekeeper/score"
 	"github.com/bdharris08/scorekeeper/store"
 )
 
@@ -13,7 +14,12 @@ var (
 )
 
 func main() {
-	scoreKeeper, err := scorekeeper.New(&store.MemoryStore{})
+	st := &store.MemoryStore{}
+	factory := score.ScoreFactory{
+		"trial": func() score.Score { return &score.Trial{} },
+	}
+
+	scoreKeeper, err := scorekeeper.New(st, factory)
 	if err != nil {
 		panic(fmt.Errorf("error creating scoreKeeper: %v", err))
 	}
@@ -41,11 +47,11 @@ func main() {
 
 	// A simple example
 	for _, a := range actions {
-		if err := scoreKeeper.AddAction(a); err != nil {
+		if err := scoreKeeper.AddAction("trial", a); err != nil {
 			fmt.Println(err)
 		}
 	}
-	result, err := scoreKeeper.GetStats()
+	result, err := scoreKeeper.GetStats("trial")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -60,11 +66,11 @@ func main() {
 		go func() {
 			defer wg.Done()
 			for _, a := range actions {
-				if err := scoreKeeper.AddAction(a); err != nil {
+				if err := scoreKeeper.AddAction("trial", a); err != nil {
 					fmt.Println(err)
 				}
 			}
-			result, err := scoreKeeper.GetStats()
+			result, err := scoreKeeper.GetStats("trial")
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -77,7 +83,7 @@ func main() {
 
 	wg.Wait()
 
-	result, err = scoreKeeper.GetStats()
+	result, err = scoreKeeper.GetStats("trial")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/example/pgsql/README.md
+++ b/example/pgsql/README.md
@@ -1,6 +1,9 @@
 # Example
 An example usage of ScoreKeeper
 
+### Prerequisites
+Have a postgreSQL database running on `host` listening to `port` with a database `db_name` which is accessible by user `user` with `password`. You can also set the dsn as an env varable `DATABASE_URL`.
+
 ### Usage
 ```sh
 cd example/pgsql

--- a/score/score.go
+++ b/score/score.go
@@ -1,9 +1,6 @@
 package score
 
 import (
-	"encoding/json"
-	"errors"
-	"strings"
 )
 
 // Score is kept by ScoreKeeper and tracks something.
@@ -39,67 +36,6 @@ func (t *TestScore) Value() interface{} {
 	return t.TValue
 }
 
-// Trial is a kind of Score. It is a timed action.
-type Trial struct {
-	Action string `json:"action"`
-	// Since the "time" units weren't specified, let's assume milliseconds as a reasonably precise
-	// human-scale time measurement. Max float64 is 1.7976931348623157e+308,
-	// or rougly 5.700447535712569×10^297 years, which seems like plenty of time to jump.
-	// We only need an int to store this data, but I don't know the edginess of the edge cases
-	// that will be used in testing.
-	Time float64 `json:"time"`
-}
-
-// AverageTime will be used to report an average time
-type AverageTime struct {
-	Action  string  `json:"action"`
-	Average float64 `json:"avg"`
-}
-
-var (
-	ErrNoInput   = errors.New("no input provided")
-	ErrBadTime   = errors.New("invalid time")
-	ErrNoTime    = errors.New("missing time")
-	ErrBadAction = errors.New("invalid action")
-	ErrBadInput  = errors.New("bad input")
-)
-
-// Name returns the trial's action
-func (t *Trial) Name() string {
-	return t.Action
-}
-
-// Value returns the trial's time
-func (t *Trial) Value() interface{} {
-	return t.Time
-}
-
-// Read a json-encoded string into the Trial struct.
-func (t *Trial) Read(action string) error {
-	if action == "" {
-		return ErrNoInput
-	}
-
-	if !strings.Contains(action, "time") {
-		return ErrNoTime
-	}
-
-	err := json.Unmarshal([]byte(action), t)
-	if err != nil {
-		if jsonErr, ok := err.(*json.UnmarshalTypeError); ok {
-			switch jsonErr.Field {
-			case "action":
-				return ErrBadAction
-			case "time":
-				return ErrBadTime
-			}
-		}
-
-		return ErrBadInput
-	}
-
-	if t.Action == "" {
-		return ErrBadAction
 	}
 
 	return nil

--- a/score/score.go
+++ b/score/score.go
@@ -1,24 +1,51 @@
 package score
 
 import (
+	"fmt"
 )
 
 // Score is kept by ScoreKeeper and tracks something.
 // We will only have one kind of Score for this project (Trial),
 // but through this interface we could extend to other kinds easily
 type Score interface {
+	// Type of score, for example "trial"
+	Type() string
 	// Generate a unique identifier for later organization.
 	Name() string
 	// Read a json-encoded string into the Score struct.
 	Read(s string) error
 	// Value returns the value of the Score.
 	Value() interface{}
+	// Set the name and value of the score
+	Set(name string, value interface{}) error
+}
+
+type ScoreConstructor func() Score
+
+type ScoreFactory map[string]ScoreConstructor
+
+func Create(f ScoreFactory, scoreType string) (Score, error) {
+	constructor, ok := f[scoreType]
+	if !ok {
+		return nil, fmt.Errorf("unregistered scoreType %s", scoreType)
+	}
+
+	return constructor(), nil
 }
 
 // TestScore is a simple score for testing.
 type TestScore struct {
 	TName  string
 	TValue float64
+}
+
+func NewTestScore() Score {
+	return &TestScore{}
+}
+
+// Type returns the type of Score
+func (t *TestScore) Type() string {
+	return "test"
 }
 
 // Name the test score.
@@ -36,7 +63,14 @@ func (t *TestScore) Value() interface{} {
 	return t.TValue
 }
 
+// Set the value and name of the TestScore
+func (t *TestScore) Set(name string, value interface{}) error {
+	f, ok := value.(float64)
+	if !ok {
+		return fmt.Errorf("failed to assert value type")
 	}
 
+	t.TName = name
+	t.TValue = f
 	return nil
 }

--- a/score/trial.go
+++ b/score/trial.go
@@ -32,6 +32,10 @@ var (
 	ErrBadInput  = errors.New("bad input")
 )
 
+func NewTrial() Score {
+	return &Trial{}
+}
+
 // Type returns the type of Score
 func (t *Trial) Type() string {
 	return "trial"
@@ -45,6 +49,18 @@ func (t *Trial) Name() string {
 // Value returns the trial's time
 func (t *Trial) Value() interface{} {
 	return t.Time
+}
+
+// Set the value and name of the Trial
+func (t *Trial) Set(name string, value interface{}) error {
+	f, ok := value.(float64)
+	if !ok {
+		return fmt.Errorf("failed to assert value type")
+	}
+
+	t.Action = name
+	t.Time = f
+	return nil
 }
 
 // Read a json-encoded string into the Trial struct.

--- a/score/trial.go
+++ b/score/trial.go
@@ -1,0 +1,79 @@
+package score
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Trial is a kind of Score. It is a timed action.
+type Trial struct {
+	Action string `json:"action"`
+	// Since the "time" units weren't specified, let's assume milliseconds as a reasonably precise
+	// human-scale time measurement. Max float64 is 1.7976931348623157e+308,
+	// or rougly 5.700447535712569×10^297 years, which seems like plenty of time to jump.
+	// We only need an int to store this data, but I don't know the edginess of the edge cases
+	// that will be used in testing.
+	Time float64 `json:"time"`
+}
+
+// AverageTime will be used to report an average time
+type AverageTime struct {
+	Action  string  `json:"action"`
+	Average float64 `json:"avg"`
+}
+
+var (
+	ErrNoInput   = errors.New("no input provided")
+	ErrBadTime   = errors.New("invalid time")
+	ErrNoTime    = errors.New("missing time")
+	ErrBadAction = errors.New("invalid action")
+	ErrBadInput  = errors.New("bad input")
+)
+
+// Type returns the type of Score
+func (t *Trial) Type() string {
+	return "trial"
+}
+
+// Name returns the trial's action
+func (t *Trial) Name() string {
+	return t.Action
+}
+
+// Value returns the trial's time
+func (t *Trial) Value() interface{} {
+	return t.Time
+}
+
+// Read a json-encoded string into the Trial struct.
+func (t *Trial) Read(action string) error {
+	if action == "" {
+		return ErrNoInput
+	}
+
+	if !strings.Contains(action, "time") {
+		return ErrNoTime
+	}
+
+	err := json.Unmarshal([]byte(action), t)
+	if err != nil {
+		if jsonErr, ok := err.(*json.UnmarshalTypeError); ok {
+			switch jsonErr.Field {
+			case "action":
+				return ErrBadAction
+			case "time":
+				return ErrBadTime
+			}
+		}
+
+		return ErrBadInput
+	}
+
+	if t.Action == "" {
+		return ErrBadAction
+	}
+
+	return nil
+}

--- a/store/memorystore.go
+++ b/store/memorystore.go
@@ -10,38 +10,33 @@ import (
 // It will be used if no other store is provided.
 // Organize scores in labeled lists.
 type MemoryStore struct {
-	S map[string][]score.Score
+	S map[string]map[string][]score.Score
 }
 
 // Store a Score in memory.
 func (ms *MemoryStore) Store(s score.Score) error {
 	if ms.S == nil {
-		ms.S = map[string][]score.Score{}
+		ms.S = map[string]map[string][]score.Score{}
 	}
 
-	ms.S[s.Name()] = append(ms.S[s.Name()], s)
+	t := s.Type()
+	n := s.Name()
 
+	if ms.S[t] == nil {
+		ms.S[t] = map[string][]score.Score{}
+	}
+
+	ms.S[t][n] = append(ms.S[t][n], s)
 	return nil
 }
 
 var ErrNoScores = errors.New("no scores found")
 
 // Retrieve Scores from memory by name.
-func (ms *MemoryStore) Retrieve() (map[string][]score.Score, error) {
+func (ms *MemoryStore) Retrieve(f score.ScoreFactory, scoreType string) (map[string][]score.Score, error) {
 	if ms.S == nil {
 		return nil, ErrNoScores
 	}
 
-	return ms.S, nil
-}
-
-// Names returns the score category names currently stored
-func (ms *MemoryStore) Names() []string {
-	names := make([]string, 0, len(ms.S))
-
-	for name := range ms.S {
-		names = append(names, name)
-	}
-
-	return names
+	return ms.S[scoreType], nil
 }

--- a/store/memorystore_test.go
+++ b/store/memorystore_test.go
@@ -7,12 +7,13 @@ import (
 )
 
 func TestMemoryStoreSimple(t *testing.T) {
+	scoreType := "test"
 	ms := MemoryStore{
-		S: map[string][]score.Score{},
+		S: map[string]map[string][]score.Score{},
 	}
 
 	s := score.TestScore{
-		TName:  "test",
+		TName:  scoreType,
 		TValue: 1,
 	}
 
@@ -20,7 +21,7 @@ func TestMemoryStoreSimple(t *testing.T) {
 		t.Error(err)
 	}
 
-	scores, err := ms.Retrieve()
+	scores, err := ms.Retrieve(nil, scoreType)
 	if err != nil {
 		t.Error(err)
 	}

--- a/store/scorestore.go
+++ b/store/scorestore.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"errors"
+
 	"github.com/bdharris08/scorekeeper/score"
 )
 
@@ -8,5 +10,7 @@ import (
 // It could be in memory or backed by a database.
 type ScoreStore interface {
 	Store(s score.Score) error
-	Retrieve() (map[string][]score.Score, error)
+	Retrieve(f score.ScoreFactory, scoreType string) (map[string][]score.Score, error)
 }
+
+var ErrNoStore = errors.New("scoreStore uninitialized")


### PR DESCRIPTION
REF: #18

Creates the concept of a Score Factory that takes a score type and returns a score constructor. This will be used to "register" score types that the score keeper can handle.
This isn't exactly "generics", but it allows us to store and retrieve arbitrary score types from the store. For now, the sql store will just use the score type as the table name. This is (has always been) fairly brittle in that we can only work with scores that have one name field and one value. But, since this was an exercise in using go interfaces, this is where I'll stop. 